### PR TITLE
Add MedDRA terms to WORDLIST so spelling check is clean

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,10 +1,15 @@
 CMD
 Codecov
+LLTs
 Lifecycle
+MSSO
 MedAscii
 MedDRA
+SMQ
+SMQs
 SeqAscii
 hlgt
 hlt
 llt
 meddra
+pre


### PR DESCRIPTION
Adds LLTs, MSSO, SMQ, SMQs, and pre (split from pre-defined) — all flagged by spelling::spell_check_package() from the vignette but legitimate domain abbreviations.